### PR TITLE
Temporarily hide "Kdo jsme" from site navigation

### DIFF
--- a/_pages/kdo-jsme/index.html
+++ b/_pages/kdo-jsme/index.html
@@ -2,6 +2,7 @@
 layout: page
 title: Kdo jsme
 permalink: /kdo-jsme/
+hiddenFromMenu: 'yes'
 ---
 
 <article class="site-page page-about-us">


### PR DESCRIPTION
Temporarily hide "Kdo jsme" from site navigation, till we make it prettier, more useful and up-to-date.