### PR TITLE
revert formating rss feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -14,7 +14,7 @@ layout: null
     {% for post in site.posts limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
+        <description>{{ post.content | strip_html | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
         <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>


### PR DESCRIPTION
- dáváme zpět, protože to rozbíjí Onás, který čerpá data z našeho blog xml feedu a neumí pracovat s HTML tagy uvnitř
- předáno na Míšu, aby to zadala na opravu