### PR TITLE
Update site-blog-category.html - tagy trailing slash

### DIFF
--- a/_includes/site-blog-category.html
+++ b/_includes/site-blog-category.html
@@ -18,7 +18,7 @@
 
                 {% for tag in post.tags %}
                 <span class="page-blog__post-tag">
-                    <a href="/tagy#{{ tag | cgi_escape }}">
+                    <a href="/tagy/#{{ tag | cgi_escape }}">
                         #{{ tag }}
                     </a>
                 </span>


### PR DESCRIPTION
Adding traling slash to /tagy/ URL.
Avoids unnecessary redirects.