### PR TITLE
Update post.html - tagy trailing slash

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -46,7 +46,7 @@ layout: default
         <ul class="site-post__tags">
             {% for tag in page.tags %}
             <li class="site-post__tag">
-                <a href="/tagy#{{ tag | cgi_escape }}">
+                <a href="/tagy/#{{ tag | cgi_escape }}">
                     #{{ tag }}
                 </a>
             </li>


### PR DESCRIPTION
Adding trailing slash to /tagy/ URL.
Avoids unnecessary redirects.